### PR TITLE
Add workflow for updating workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ The `setup-workflows.yml` workflow checkouts this repository once a day in the r
 
 1. Copy `workflows/setup-workflows.yml` workflow to your repository.
 1. Setup `secrets.BOT_USERNAME` and `secrets.BOT_EMAIL` to GitHub user which has a push access to your repository.
-1. Setup `secrets.TOKEN_WORKFLOWS` to GitHub token which has `workflows` permission.
+1. Setup `secrets.GH_WORKFLOWS_TOKEN` to GitHub token which has `workflows` permission.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Shared CKEditor 4 GitHub workflows.
 
 The main function of `setup-workflows.yml` workflow is to propagate common workflows and keep them up to date.
 
-The `setup-workflows.yml` workflow works in a way that it checkouts this repository once a day in repository it is executed and updates (or creates) all common workflows. Common workflows are stored in `./workflows/` directory. There is also `setup-workflows.yml` workflow there, which means, once it is set it will auto update itself too.
+The `setup-workflows.yml` workflow works in a way that it checkouts this repository once a day in a repository it is executed and updates (or creates) all common workflows. Common workflows are stored in `./workflows/` directory. There is also `setup-workflows.yml` workflow, which means, once it is set it will auto update itself too.
 
 ## Setup
 
 1. Copy `workflows/setup-workflows.yml` workflow to your repository.
 1. Setup `secrets.BOT_USERNAME` and `secrets.BOT_EMAIL` to GitHub user which has a push access to your repository.
+1. Setup `secrets.TOKEN_WORKFLOWS` to GitHub token which has `workflows` permission.

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ The `setup-workflows.yml` workflow checkouts this repository once a day in the r
 ## Setup
 
 1. Copy `workflows/setup-workflows.yml` workflow to your repository.
-1. Setup `secrets.BOT_USERNAME` and `secrets.BOT_EMAIL` to GitHub user which has a push access to your repository.
+1. Setup `secrets.GH_BOT_USERNAME` and `secrets.GH_BOT_EMAIL` to GitHub user which has a push access to your repository.
 1. Setup `secrets.GH_WORKFLOWS_TOKEN` to GitHub token which has `workflows` permission.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ Shared CKEditor 4 GitHub workflows.
 
 The main function of `setup-workflows.yml` workflow is to propagate common workflows and keep them up to date.
 
-The `setup-workflows.yml` workflow works in a way that it checkouts this repository once a day in repository it is executed and updates (or creates) all common workflows. Common workflows are stored in `./workflows/` directory. There is also `setup-workflows.yml` workflow there which means, once it is set it will auto update itself too.
+The `setup-workflows.yml` workflow works in a way that it checkouts this repository once a day in repository it is executed and updates (or creates) all common workflows. Common workflows are stored in `./workflows/` directory. There is also `setup-workflows.yml` workflow there, which means, once it is set it will auto update itself too.
 
 ## Setup
 
 1. Copy `workflows/setup-workflows.yml` workflow to your repository.
 1. Setup `secrets.BOT_USERNAME` and `secrets.BOT_EMAIL` to GitHub user which has a push access to your repository.
-
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Shared CKEditor 4 GitHub workflows.
 
 The main function of `setup-workflows.yml` workflow is to propagate common workflows and keep them up to date.
 
-The `setup-workflows.yml` workflow works in a way that it checkouts this repository once a day in a repository it is executed and updates (or creates) all common workflows. Common workflows are stored in `./workflows/` directory. There is also `setup-workflows.yml` workflow, which means, once it is set it will auto update itself too.
+The `setup-workflows.yml` workflow checkouts this repository once a day in the repository it is executed and updates (or creates) all common workflows. Common workflows are stored in `./workflows/` directory. There is also `setup-workflows.yml` workflow there, which means, once it is set it will auto-update itself too.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # CKEditor 4 Workflows Common
 
 Shared CKEditor 4 GitHub workflows.
+
+## How it works?
+
+The main function of `setup-workflows.yml` workflow is to propagate common workflows and keep them up to date.
+
+The `setup-workflows.yml` workflow works in a way that it checkouts this repository once a day in repository it is executed and updates (or creates) all common workflows. Common workflows are stored in `./workflows/` directory. There is also `setup-workflows.yml` workflow there which means, once it is set it will auto update itself too.
+
+## Setup
+
+1. Copy `workflows/setup-workflows.yml` workflow to your repository.
+1. Setup `secrets.BOT_USERNAME` and `secrets.BOT_EMAIL` to GitHub user which has a push access to your repository.
+
+

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -13,7 +13,7 @@ jobs:
         # https://github.com/marketplace/actions/checkout
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.TOKEN_WORKFLOWS }}
+          token: ${{ secrets.GH_WORKFLOWS_TOKEN }}
 
       - name: Checkout common workflows repository
         # https://github.com/marketplace/actions/checkout
@@ -51,5 +51,5 @@ jobs:
         # https://github.com/marketplace/actions/github-push
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.TOKEN_WORKFLOWS }}
+          github_token: ${{ secrets.GH_WORKFLOWS_TOKEN }}
           branch: ${{ github.ref }}

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -31,7 +31,7 @@ jobs:
             if [[ -e "$file" ]]; then
               newFile=$(basename $file)
               existingFile="./.github/workflows/$newFile"
-              if [[ -e "$existingFile" && $(diff "$newFile" "$existingFile" | wc -c) -ne 0 ]]; then
+              if [[ -e "$existingFile" && $(diff "$file" "$existingFile" | wc -c) -ne 0 ]]; then
                 echo "Updating $newFile workflow..."
                 cp $file $existingFile
                 echo "HAS_CHANGES=1" >> $GITHUB_ENV

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -12,6 +12,8 @@ jobs:
       - name: Checkout default branch
         # https://github.com/marketplace/actions/checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.TOKEN_WORKFLOWS }}
 
       - name: Checkout common workflows repository
         # https://github.com/marketplace/actions/checkout
@@ -60,5 +62,5 @@ jobs:
         # https://github.com/marketplace/actions/github-push
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.TOKEN_WORKFLOWS }}
           branch: ${{ github.ref }}

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -29,21 +29,10 @@ jobs:
 
       - name: Copy workflow files
         run: |
-          for file in ./ckeditor4-workflows-common/workflows/*.yml; do
-            if [[ -e "$file" ]]; then
-              newFile=$(basename $file)
-              existingFile="./.github/workflows/$newFile"
-              if [[ -e "$existingFile" && $(diff "$file" "$existingFile" | wc -c) -ne 0 ]]; then
-                echo "Updating $newFile workflow..."
-                cp $file $existingFile
-                echo "HAS_CHANGES=1" >> $GITHUB_ENV
-              else
-                echo "Creating $newFile workflow..."
-                cp $file $existingFile
-                echo "HAS_CHANGES=1" >> $GITHUB_ENV
-              fi
-            fi
-          done
+          rsync -a --include='*/' --include='*.yml' --exclude='*' ./ckeditor4-workflows-common/workflows/ ./.github/workflows/
+          if [[ $(git status --porcelain) ]]; then
+              echo "HAS_CHANGES=1"
+          fi
 
       - name: Cleanup common workflows artifacts
         run: |

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Add changes
         if: env.HAS_CHANGES == 1
         run: |
-          git config --local user.email "${{ secrets.BOT_EMAIL }}"
-          git config --local user.name "${{ secrets.BOT_USERNAME }}"
+          git config --local user.email "${{ secrets.GH_BOT_EMAIL }}"
+          git config --local user.name "${{ secrets.GH_BOT_USERNAME }}"
           git add .github/workflows
           git commit -m "Update common workflows."
 

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -17,7 +17,7 @@ jobs:
         # https://github.com/marketplace/actions/checkout
         uses: actions/checkout@v2
         with:
-          path: _workflows
+          path: ckeditor4-workflows-common
           repository: ckeditor/ckeditor4-workflows-common
           ref: master
 
@@ -27,7 +27,7 @@ jobs:
 
       - name: Copy workflow files
         run: |
-          for file in ./_workflows/*.yml; do
+          for file in ./ckeditor4-workflows-common/workflows/*.yml; do
             if [[ -e "$file" ]]; then
               newFile=$(basename $file)
               existingFile="./.github/workflows/$newFile"
@@ -45,7 +45,7 @@ jobs:
 
       - name: Cleanup common workflows artifacts
         run: |
-          rm -rf _workflows
+          rm -rf ckeditor4-workflows-common
 
       - name: Add changes
         if: env.HAS_CHANGES == 1

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -34,9 +34,11 @@ jobs:
               if [[ -e "$existingFile" && $(diff "$newFile" "$existingFile" | wc -c) -ne 0 ]]; then
                 echo "Updating $newFile workflow..."
                 cp $file $existingFile
+                echo "HAS_CHANGES=1" >> $GITHUB_ENV
               else
                 echo "Creating $newFile workflow..."
                 cp $file $existingFile
+                echo "HAS_CHANGES=1" >> $GITHUB_ENV
               fi
             fi
           done

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           rsync -a --include='*/' --include='*.yml' --exclude='*' ./ckeditor4-workflows-common/workflows/ ./.github/workflows/
           if [[ $(git status --porcelain) ]]; then
-              echo "HAS_CHANGES=1"
+              echo "HAS_CHANGES=1" >> $GITHUB_ENV
           fi
 
       - name: Cleanup common workflows artifacts

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -1,0 +1,62 @@
+name: Setup and update common workflows
+
+on:
+  schedule:
+  - cron: "0 2 * * *"
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout default branch
+        # https://github.com/marketplace/actions/checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout common workflows repository
+        # https://github.com/marketplace/actions/checkout
+        uses: actions/checkout@v2
+        with:
+          path: _workflows
+          repository: ckeditor/ckeditor4-workflows-common
+          ref: master
+
+      - name: Setup workflows directory
+        run: |
+          mkdir -p .github/workflows
+
+      - name: Copy workflow files
+        run: |
+          for file in ./_workflows/*.yml; do
+            if [[ -e "$file" ]]; then
+              newFile=$(basename $file)
+              existingFile="./.github/workflows/$newFile"
+              if [[ -e "$existingFile" && $(diff "$newFile" "$existingFile" | wc -c) -ne 0 ]]; then
+                echo "Updating $newFile workflow..."
+                cp $file $existingFile
+              else
+                echo "Creating $newFile workflow..."
+                cp $file $existingFile
+              fi
+            fi
+          done
+
+      - name: Cleanup common workflows artifacts
+        run: |
+          rm -rf _workflows
+
+      - name: Add changes
+        if: env.HAS_CHANGES == 1
+        run: |
+          git config --local user.email "${{ secrets.BOT_EMAIL }}"
+          git config --local user.name "${{ secrets.BOT_USERNAME }}"
+          git add .github/workflows
+          git commit -m "Update common workflows."
+
+      - name: Push changes
+        if: env.HAS_CHANGES == 1
+        # https://github.com/marketplace/actions/github-push
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}


### PR DESCRIPTION
I decided to add the main/template action as a PR so we can review it and work as normal instead of creating it via GH editor which will be cumbersome.

Also the funny thing is that if this action will be included here it can auto-update itself too I suppose :thinking: So not sure if we should move it as template or leave here eventually.

~This is WIP since I need to test how it works.~ Checked in [workflows-setup-test](https://github.com/f1ames/workflows-setup-test/actions) repo. The only issue there is that, since it is user (not organization) repo, CKEditor Bot has [Collaborator access level](https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-your-github-user-account/permission-levels-for-a-user-account-repository) which means it can't push new workflows - that's why it fails on push step (see e.g. https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-your-github-user-account/permission-levels-for-a-user-account-repository). However, based on logs you can tell it works fine creating/updating workflow files.