### PR TITLE
Allow 'setup-workflows' to create a PR instead of pushing to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ Workflow responsible for updating NPM dependencies. It is run once a week (at 05
 * `GH_BOT_EMAIL` - GitHub user email which acts as an author of all commits done by this job.
 * `GH_BOT_USERNAME` - GitHub user username which acts as an author of all commits done by this job.
 
-#### Optional secrets
+#### Optional configuration
 
-* `BRANCH_MAIN` - Target branch name. By default, workflow runs on main repository branch.
+* `updateDeps.branchMain` : `String` Target branch name. By default, workflow runs on main repository branch.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,25 @@ The `setup-workflows.yml` workflow checkouts this repository once a day in the t
 
 Some workflows may be altered by configuration options (refer to [Available workflows](#available-workflows) section below). The configuration file is optional and not present by default. If needed, it should be added to any repository using common workflows as `.github/workflows-config.json` file.
 
+### Loading configuration file
+
+For any workflow which needs to load and use configuration values, it is recommended to load config as first step of entire workflow using [jq](https://stedolan.github.io/jq/) like:
+
+```json
+- name: Read config
+  run: |
+    echo "SETTINGS={}" >> $GITHUB_ENV
+    if [[ -f "./.github/workflows-config.json" ]]; then
+      echo "SETTINGS=$( jq './.github/workflows-config.json' )" >> $GITHUB_ENV
+    fi
+```
+
+Then, further in the workflow any step can use $SETTINGS variable and read any configuration properties like:
+
+```bash
+$(echo ${{ env.SETTINGS }} | jq ".propertyName")
+```
+
 ## Available workflows
 
 ### setup-workflows

--- a/README.md
+++ b/README.md
@@ -4,12 +4,64 @@ Shared CKEditor 4 GitHub workflows.
 
 ## How it works?
 
-The main function of `setup-workflows.yml` workflow is to propagate common workflows and keep them up to date.
+The main function of this repository is to propagate common workflows and keep them up to date.
 
-The `setup-workflows.yml` workflow checkouts this repository once a day in the repository it is executed and updates (or creates) all common workflows. Common workflows are stored in `./workflows/` directory. There is also `setup-workflows.yml` workflow there, which means, once it is set it will auto-update itself too.
+The `setup-workflows.yml` workflow checkouts this repository once a day in the target repository and updates (or creates) all common workflows. Common workflows are stored in `workflows/` directory here and are copied to `.github/workflows/` directory in a target repository. There is also `setup-workflows.yml` workflow there, which means, once it is set it will auto-update itself too.
 
 ## Setup
 
-1. Copy `workflows/setup-workflows.yml` workflow to your repository.
+1. Copy `workflows/setup-workflows.yml` workflow to your repository as `.github/workflows/setup-workflows.yml`.
 1. Setup `secrets.GH_BOT_USERNAME` and `secrets.GH_BOT_EMAIL` to GitHub user which has a push access to your repository.
-1. Setup `secrets.GH_WORKFLOWS_TOKEN` to GitHub token which has `workflows` permission.
+1. Setup `secrets.GH_WORKFLOWS_TOKEN` to GitHub token which has `write` and `workflows` permissions.
+
+## Optional configuration
+
+Some workflows may be altered by configuration options (refer to [Available workflows](#available-workflows) section below). The configuration file is optional and not present by default. If needed, it should be added to any repository using common workflows as `.github/workflows-config.json` file.
+
+## Available workflows
+
+### setup-workflows
+
+This is the main workflow responsible for propagating all common workflows. When it is added to any other repository it checkouts this repository and copies all common workflows from `workflows/` directory to `.github/workflows/` one. It is done once a day so any changes are propagated on a daily basis. See `workflows/setup-workflows.yml` file.
+
+It is a cron job task so will be triggered only on main repository branch.
+
+#### Required secrets
+
+* `GH_WORKFLOWS_TOKEN` - GitHub token which is used for all commit/push/pr actions. It should have write and workflows access.
+* `GH_BOT_EMAIL` - GitHub user email which acts as an author of all commits done by this job.
+* `GH_BOT_USERNAME` - GitHub user username which acts as an author of all commits done by this job.
+
+#### Optional configuration
+
+* `setupWorkflows.pushAsPullRequest` : `Boolean` If set to true, workflows update will be created as PR instead of being pushed directly to the main branch.
+
+### stalebot
+
+Workflow responsible for handling stale issues and PRs. It is a cron job task so will be triggered only on a main repository branch. See `workflows/stalebot.yml` file.
+
+#### Required secrets
+
+_None_
+
+#### Other requirements
+
+Since this workflow uses labels to mark stale issues/PRs, labels should be already defined in the target repository:
+
+* `stale` - label used to mark stale issues/PRs.
+* `status:confirmed` - label used to filter out confirmed issues. Such issues are not processed by `stalebot`.
+* `resolution:expired` - label added to stale issues which got closed due to inactivity.
+* `pr:frozen ❄` - label added to stale PRs which got closed due to inactivity.
+
+### update-deps
+
+Workflow responsible for updating NPM dependencies. It is run once a week and creates two PRs (if there are any outdated dependencies) - one for dev dependencies and one for production ones. It checks `package.json` file in the repository root and uses `npm-check` to update all dev/prod dependencies (which means `package.json` versioning is not respected). It is a cron job task so will be triggered only on main repository branch. See `workflows/update-deps.yml` file.
+
+#### Required secrets
+
+* `GH_BOT_EMAIL` - GitHub user email which acts as an author of all commits done by this job.
+* `GH_BOT_USERNAME` - GitHub user username which acts as an author of all commits done by this job.
+
+#### Optional secrets
+
+* `BRANCH_MAIN` - Target branch name. By default, workflow runs on main repository branch.

--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ Workflow responsible for updating NPM dependencies. It is run once a week (at 05
 
 #### Optional configuration
 
-* `updateDeps.branchMain` : `String` Target branch name. By default, workflow runs on main repository branch.
+* `updateDeps.targetBranch` : `String` Target branch name. By default, workflow runs on main repository branch.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $(echo ${{ env.SETTINGS }} | jq ".propertyName")
 
 ### setup-workflows
 
-This is the main workflow responsible for propagating all common workflows. When it is added to any other repository it checkouts this repository and copies all common workflows from `workflows/` directory to `.github/workflows/` one. It is done once a day so any changes are propagated on a daily basis. See `workflows/setup-workflows.yml` file.
+This is the main workflow responsible for propagating all common workflows. When it is added to any other repository it checkouts this repository and copies all common workflows from `workflows/` directory to `.github/workflows/` one. It is run once a day (at 02:00 UTC) so any changes are propagated on a daily basis. See `workflows/setup-workflows.yml` file.
 
 It is a cron job task so will be triggered only on main repository branch.
 
@@ -74,7 +74,7 @@ Since this workflow uses labels to mark stale issues/PRs, labels should be alrea
 
 ### update-deps
 
-Workflow responsible for updating NPM dependencies. It is run once a week and creates two PRs (if there are any outdated dependencies) - one for dev dependencies and one for production ones. It checks `package.json` file in the repository root and uses `npm-check` to update all dev/prod dependencies (which means `package.json` versioning is not respected). It is a cron job task so will be triggered only on main repository branch. See `workflows/update-deps.yml` file.
+Workflow responsible for updating NPM dependencies. It is run once a week (at 05:00 UTC on Monday) and creates two PRs (if there are any outdated dependencies) - one for dev dependencies and one for production ones. It checks `package.json` file in the repository root and uses `npm-check` to update all dev/prod dependencies (which means `package.json` versioning is not respected). It is a cron job task so will be triggered only on main repository branch. See `workflows/update-deps.yml` file.
 
 #### Required secrets
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Some workflows may be altered by configuration options (refer to [Available work
 
 For any workflow which needs to load and use configuration values, it is recommended to load config as first step of entire workflow using [jq](https://stedolan.github.io/jq/) like:
 
-```json
+```yml
 - name: Read config
   run: |
     echo "SETTINGS={}" >> $GITHUB_ENV
     if [[ -f "./.github/workflows-config.json" ]]; then
-      echo "SETTINGS=$( jq './.github/workflows-config.json' )" >> $GITHUB_ENV
+      echo "SETTINGS=$( jq .workflowName './.github/workflows-config.json' )" >> $GITHUB_ENV
     fi
 ```
 

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -32,6 +32,32 @@ jobs:
           echo "CONFIG=$CONFIG" >> $GITHUB_ENV
           echo "Workflow config: $CONFIG"
 
+      - name: Process config
+        run: |
+          AS_PR=$(echo '${{ env.CONFIG }}' | jq -r ".pushAsPullRequest")
+          if [[ "$AS_PR" == "true" ]]; then
+            echo "AS_PR=1" >> $GITHUB_ENV
+          elif
+            echo "AS_PR=0" >> $GITHUB_ENV
+          fi
+          BRANCH_SOURCE=$(git rev-parse --abbrev-ref HEAD)
+          if [[ "$AS_PR" == "true" ]]; then
+            BRANCH_SOURCE="t/setup-workflows-update_$BRANCH_SOURCE"
+          fi
+          echo "BRANCH_SOURCE=$BRANCH_SOURCE" >> $GITHUB_ENV
+
+      - name: Check if update branch already exists
+        if: env.AS_PR == 1
+        run: |
+          if [[ $(git ls-remote --heads | grep ${{ env.BRANCH_SOURCE }} | wc -c) -ne 0 ]]; then
+            echo "SHOULD_CANCEL=1" >> $GITHUB_ENV
+          fi
+
+      - name: Cancel build if update branch already exists
+        if: env.SHOULD_CANCEL == 1
+        # https://github.com/marketplace/actions/cancel-this-build
+        uses: andymckay/cancel-action@0.2
+
       - name: Checkout common workflows repository
         # https://github.com/marketplace/actions/checkout
         uses: actions/checkout@v2
@@ -55,17 +81,10 @@ jobs:
         run: |
           rm -rf ckeditor4-workflows-common
 
-      - name: Prepare PR branch
+      - name: Checkout PR branch
         if: env.HAS_CHANGES == 1
         run: |
-          BRANCH_SOURCE=$(git rev-parse --abbrev-ref HEAD)
-          AS_PR=$(echo '${{ env.CONFIG }}' | jq -r ".pushAsPullRequest")
-          if [[ "$AS_PR" == "true" ]]; then
-            BRANCH_SOURCE="t/setup-workflows-update_$BRANCH_SOURCE"
-            echo "AS_PR=1" >> $GITHUB_ENV
-            git checkout -b t/$BRANCH_SOURCE
-          fi
-          echo "BRANCH_SOURCE=$BRANCH_SOURCE" >> $GITHUB_ENV
+          git checkout -b "t/${{ env.BRANCH_SOURCE }}"
 
       - name: Add changes
         if: env.HAS_CHANGES == 1

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -58,13 +58,14 @@ jobs:
       - name: Prepare PR branch
         if: env.HAS_CHANGES == 1
         run: |
-          echo "BRANCH_NAME=${{ github.ref }}" >> $GITHUB_ENV
-          pushAsPullRequest=$(echo ${{ env.SETTINGS }} | jq ".pushAsPullRequest")
-          if [[ "$pushAsPullRequest" == true ]]; then
+          BRANCH_NAME='${{ github.ref }}'
+          AS_PR=$(echo '${{ env.CONFIG }}' | jq -r ".pushAsPullRequest")
+          if [[ "$AS_PR" == "true" ]]; then
+            BRANCH_NAME="t/setup-workflows-update_$BRANCH_NAME"
             echo "AS_PR=1" >> $GITHUB_ENV
-            echo "BRANCH_NAME=t/setup-workflows-update" >> $GITHUB_ENV
-            git checkout -b t/setup-workflows-update
+            git checkout -b t/$BRANCH_NAME
           fi
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
       - name: Add changes
         if: env.HAS_CHANGES == 1

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -58,6 +58,13 @@ jobs:
         # https://github.com/marketplace/actions/cancel-this-build
         uses: andymckay/cancel-action@0.2
 
+      - name: Wait for cancellation
+        if: env.SHOULD_CANCEL == 1
+        # https://github.com/marketplace/actions/wait-sleep
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '60s'
+
       - name: Checkout common workflows repository
         # https://github.com/marketplace/actions/checkout
         uses: actions/checkout@v2

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -2,7 +2,13 @@ name: Setup and update common workflows
 
 on:
   schedule:
-  - cron: "0 2 * * *"
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      config:
+        description: 'Config'
+        required: false
+        default: ''
 
 jobs:
   update:
@@ -11,10 +17,14 @@ jobs:
     steps:
       - name: Read config
         run: |
-          echo "SETTINGS={}" >> $GITHUB_ENV
-          if [[ -f "./.github/workflows-config.json" ]]; then
-            echo "SETTINGS=$( jq .setupWorkflows './.github/workflows-config.json' )" >> $GITHUB_ENV
+          CONFIG='{}'
+          if [[ ! -z '${{ github.event.inputs.config }}' ]]; then
+            CONFIG='${{ github.event.inputs.config }}'
+          elif [[ -f "./.github/workflows-config.json" ]]; then
+            CONFIG=$( jq .setupWorkflows './.github/workflows-config.json' )
           fi
+          echo "CONFIG=$CONFIG" >> $GITHUB_ENV
+          echo "Workflow config: $CONFIG"
 
       - name: Checkout default branch
         # https://github.com/marketplace/actions/checkout

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -15,22 +15,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout default branch
+        # https://github.com/marketplace/actions/checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_WORKFLOWS_TOKEN }}
+
       - name: Read config
         run: |
           CONFIG='{}'
           if [[ ! -z '${{ github.event.inputs.config }}' ]]; then
             CONFIG='${{ github.event.inputs.config }}'
           elif [[ -f "./.github/workflows-config.json" ]]; then
-            CONFIG=$( jq .setupWorkflows './.github/workflows-config.json' )
+            CONFIG=$( jq -c .setupWorkflows './.github/workflows-config.json' )
           fi
           echo "CONFIG=$CONFIG" >> $GITHUB_ENV
           echo "Workflow config: $CONFIG"
-
-      - name: Checkout default branch
-        # https://github.com/marketplace/actions/checkout
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.GH_WORKFLOWS_TOKEN }}
 
       - name: Checkout common workflows repository
         # https://github.com/marketplace/actions/checkout

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Prepare PR branch
         if: env.HAS_CHANGES == 1
         run: |
-          BRANCH_SOURCE='${{ github.ref }}'
+          BRANCH_SOURCE=$(git rev-parse --abbrev-ref HEAD)
           AS_PR=$(echo '${{ env.CONFIG }}' | jq -r ".pushAsPullRequest")
           if [[ "$AS_PR" == "true" ]]; then
             BRANCH_SOURCE="t/setup-workflows-update_$BRANCH_SOURCE"

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -38,6 +38,19 @@ jobs:
         run: |
           rm -rf ckeditor4-workflows-common
 
+      - name: Prepare PR branch
+        if: env.HAS_CHANGES == 1
+        run: |
+          echo "BRANCH_NAME=${{ github.ref }}" >> $GITHUB_ENV
+          if [[ -f "./.github/workflows-config.json" ]]; then
+            pushAsPullRequest=$(jq ".setupWorkflows.pushAsPullRequest" "./.github/workflows-config.json")
+            if [[ "$pushAsPullRequest" == true ]]; then
+              echo "AS_PR=1" >> $GITHUB_ENV
+              echo "BRANCH_NAME=t/setup-workflows-update" >> $GITHUB_ENV
+              git checkout -b t/setup-workflows-update
+            fi
+          fi
+
       - name: Add changes
         if: env.HAS_CHANGES == 1
         run: |
@@ -52,4 +65,15 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GH_WORKFLOWS_TOKEN }}
-          branch: ${{ github.ref }}
+          branch: ${{ env.BRANCH_NAME }}
+
+      - name: Create PR
+        if: env.AS_PR == 1
+        # https://github.com/marketplace/actions/github-pull-request-action
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "${{ env.BRANCH_NAME }}"
+          destination_branch: "${{ github.ref }}"
+          pr_title: "Update 'setup-workflows' workflow"
+          pr_body: "Update 'setup-workflows' workflow."
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -37,7 +37,7 @@ jobs:
           AS_PR=$(echo '${{ env.CONFIG }}' | jq -r ".pushAsPullRequest")
           if [[ "$AS_PR" == "true" ]]; then
             echo "AS_PR=1" >> $GITHUB_ENV
-          elif
+          else
             echo "AS_PR=0" >> $GITHUB_ENV
           fi
           BRANCH_SOURCE=$(git rev-parse --abbrev-ref HEAD)

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           echo "SETTINGS={}" >> $GITHUB_ENV
           if [[ -f "./.github/workflows-config.json" ]]; then
-            echo "SETTINGS=$( jq './.github/workflows-config.json' )" >> $GITHUB_ENV
+            echo "SETTINGS=$( jq .setupWorkflows './.github/workflows-config.json' )" >> $GITHUB_ENV
           fi
 
       - name: Checkout default branch
@@ -49,7 +49,7 @@ jobs:
         if: env.HAS_CHANGES == 1
         run: |
           echo "BRANCH_NAME=${{ github.ref }}" >> $GITHUB_ENV
-          pushAsPullRequest=$(echo ${{ env.SETTINGS }} | jq ".setupWorkflows.pushAsPullRequest")
+          pushAsPullRequest=$(echo ${{ env.SETTINGS }} | jq ".pushAsPullRequest")
           if [[ "$pushAsPullRequest" == true ]]; then
             echo "AS_PR=1" >> $GITHUB_ENV
             echo "BRANCH_NAME=t/setup-workflows-update" >> $GITHUB_ENV

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -58,14 +58,14 @@ jobs:
       - name: Prepare PR branch
         if: env.HAS_CHANGES == 1
         run: |
-          BRANCH_NAME='${{ github.ref }}'
+          BRANCH_SOURCE='${{ github.ref }}'
           AS_PR=$(echo '${{ env.CONFIG }}' | jq -r ".pushAsPullRequest")
           if [[ "$AS_PR" == "true" ]]; then
-            BRANCH_NAME="t/setup-workflows-update_$BRANCH_NAME"
+            BRANCH_SOURCE="t/setup-workflows-update_$BRANCH_SOURCE"
             echo "AS_PR=1" >> $GITHUB_ENV
-            git checkout -b t/$BRANCH_NAME
+            git checkout -b t/$BRANCH_SOURCE
           fi
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "BRANCH_SOURCE=$BRANCH_SOURCE" >> $GITHUB_ENV
 
       - name: Add changes
         if: env.HAS_CHANGES == 1
@@ -81,14 +81,14 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GH_WORKFLOWS_TOKEN }}
-          branch: ${{ env.BRANCH_NAME }}
+          branch: ${{ env.BRANCH_SOURCE }}
 
       - name: Create PR
         if: env.AS_PR == 1
         # https://github.com/marketplace/actions/github-pull-request-action
         uses: repo-sync/pull-request@v2
         with:
-          source_branch: "${{ env.BRANCH_NAME }}"
+          source_branch: "${{ env.BRANCH_SOURCE }}"
           destination_branch: "${{ github.ref }}"
           pr_title: "Update 'setup-workflows' workflow"
           pr_body: "Update 'setup-workflows' workflow."

--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -9,6 +9,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Read config
+        run: |
+          echo "SETTINGS={}" >> $GITHUB_ENV
+          if [[ -f "./.github/workflows-config.json" ]]; then
+            echo "SETTINGS=$( jq './.github/workflows-config.json' )" >> $GITHUB_ENV
+          fi
+
       - name: Checkout default branch
         # https://github.com/marketplace/actions/checkout
         uses: actions/checkout@v2
@@ -42,13 +49,11 @@ jobs:
         if: env.HAS_CHANGES == 1
         run: |
           echo "BRANCH_NAME=${{ github.ref }}" >> $GITHUB_ENV
-          if [[ -f "./.github/workflows-config.json" ]]; then
-            pushAsPullRequest=$(jq ".setupWorkflows.pushAsPullRequest" "./.github/workflows-config.json")
-            if [[ "$pushAsPullRequest" == true ]]; then
-              echo "AS_PR=1" >> $GITHUB_ENV
-              echo "BRANCH_NAME=t/setup-workflows-update" >> $GITHUB_ENV
-              git checkout -b t/setup-workflows-update
-            fi
+          pushAsPullRequest=$(echo ${{ env.SETTINGS }} | jq ".setupWorkflows.pushAsPullRequest")
+          if [[ "$pushAsPullRequest" == true ]]; then
+            echo "AS_PR=1" >> $GITHUB_ENV
+            echo "BRANCH_NAME=t/setup-workflows-update" >> $GITHUB_ENV
+            git checkout -b t/setup-workflows-update
           fi
 
       - name: Add changes

--- a/workflows/update-deps.yml
+++ b/workflows/update-deps.yml
@@ -19,26 +19,20 @@ jobs:
         deps: [production, dev-only]
 
     steps:
+      - name: Checkout default branch
+        # https://github.com/marketplace/actions/checkout
+        uses: actions/checkout@v2
+
       - name: Read config
         run: |
           CONFIG='{}'
           if [[ ! -z '${{ github.event.inputs.config }}' ]]; then
             CONFIG='${{ github.event.inputs.config }}'
           elif [[ -f "./.github/workflows-config.json" ]]; then
-            CONFIG=$( jq .updateDeps './.github/workflows-config.json' )
+            CONFIG=$( jq -c .updateDeps './.github/workflows-config.json' )
           fi
           echo "CONFIG=$CONFIG" >> $GITHUB_ENV
           echo "Workflow config: $CONFIG"
-
-      - name: Setup node
-        # https://github.com/marketplace/actions/setup-node-js-environment
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12'
-
-      - name: Fetch changes
-        # https://github.com/marketplace/actions/checkout
-        uses: actions/checkout@v2
 
       - name: Check env variables
         run: |

--- a/workflows/update-deps.yml
+++ b/workflows/update-deps.yml
@@ -44,17 +44,17 @@ jobs:
             echo "Expected 'GH_BOT_EMAIL' secret variable to be set."
             exit 1
           fi
-          BRANCH_MAIN=$(echo '${{ env.CONFIG }}' | jq -r ".branchMain")
-          if [[ -z "$BRANCH_MAIN" || "$BRANCH_MAIN" == "null" ]]; then
+          BRANCH_TARGET=$(echo '${{ env.CONFIG }}' | jq -r ".targetBranch")
+          if [[ -z "$BRANCH_TARGET" || "$BRANCH_TARGET" == "null" ]]; then
             # Since 'Fetch changes' step fetches default branch, we just get branch name (which will be default one).
-            BRANCH_MAIN=$(git rev-parse --abbrev-ref HEAD)
+            BRANCH_TARGET=$(git rev-parse --abbrev-ref HEAD)
           fi
-          echo "BRANCH_MAIN=$BRANCH_MAIN" >> $GITHUB_ENV
+          echo "BRANCH_TARGET=$BRANCH_TARGET" >> $GITHUB_ENV
 
       - name: Check if update branch already exists
         run: |
-          echo "BRANCH_UPDATE=deps-update_${{ env.BRANCH_MAIN }}_${{ matrix.deps }}" >> $GITHUB_ENV
-          if [[ $(git ls-remote --heads | grep deps-update_${{ env.BRANCH_MAIN }}_${{ matrix.deps }} | wc -c) -ne 0 ]]; then
+          echo "BRANCH_UPDATE=deps-update_${{ env.BRANCH_TARGET }}_${{ matrix.deps }}" >> $GITHUB_ENV
+          if [[ $(git ls-remote --heads | grep deps-update_${{ env.BRANCH_TARGET }}_${{ matrix.deps }} | wc -c) -ne 0 ]]; then
             echo "BRANCH_UPDATE=0" >> $GITHUB_ENV
           fi
 
@@ -69,7 +69,7 @@ jobs:
       - name: Add changes
         if: env.BRANCH_UPDATE != 0
         run: |
-          if [[ $(git diff origin/${{ env.BRANCH_MAIN }} | wc -c) -ne 0 ]]; then
+          if [[ $(git diff origin/${{ env.BRANCH_TARGET }} | wc -c) -ne 0 ]]; then
             git config --local user.email "${{ secrets.GH_BOT_EMAIL }}"
             git config --local user.name "${{ secrets.GH_BOT_USERNAME }}"
             git add package*.json
@@ -91,7 +91,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           source_branch: "${{ env.BRANCH_UPDATE }}"
-          destination_branch: "${{ env.BRANCH_MAIN }}"
+          destination_branch: "${{ env.BRANCH_TARGET }}"
           pr_title: "Update NPM ${{ matrix.deps }} dependencies"
           pr_body: "Updated NPM ${{ matrix.deps }} dependencies."
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/workflows/update-deps.yml
+++ b/workflows/update-deps.yml
@@ -13,6 +13,13 @@ jobs:
         deps: [production, dev-only]
 
     steps:
+      - name: Read config
+        run: |
+          echo "SETTINGS={}" >> $GITHUB_ENV
+          if [[ -f "./.github/workflows-config.json" ]]; then
+            echo "SETTINGS=$( jq .updateDeps './.github/workflows-config.json' )" >> $GITHUB_ENV
+          fi
+
       - name: Setup node
         # https://github.com/marketplace/actions/setup-node-js-environment
         uses: actions/setup-node@v1
@@ -24,10 +31,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check env variables
-        # Expected secrets variables:
-        # GH_BOT_USERNAME - GH user name which will be used to push changes.
-        # GH_BOT_EMAIL - GH user email which will be used to push changes.
-        # [BRANCH_MAIN] - Target branch name (optional), if not set default branch will be used.
         run: |
           if [[ -z "${{ secrets.GH_BOT_USERNAME }}" ]]; then
             echo "Expected 'GH_BOT_USERNAME' secret variable to be set."
@@ -37,11 +40,12 @@ jobs:
             echo "Expected 'GH_BOT_EMAIL' secret variable to be set."
             exit 1
           fi
-          if [[ -z "${{ secrets.BRANCH_MAIN }}" ]]; then
+          BRANCH_MAIN=$(echo ${{ env.SETTINGS }} | jq ".branchMain")
+          if [[ -z "$BRANCH_MAIN" ]]; then
             # Since 'Fetch changes' step fetches default branch, we just get branch name (which will be default one).
             echo "BRANCH_MAIN=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
           else
-            echo "BRANCH_MAIN=${{ secrets.BRANCH_MAIN }}" >> $GITHUB_ENV
+            echo "$BRANCH_MAIN" >> $GITHUB_ENV
           fi
 
       - name: Check if update branch already exists

--- a/workflows/update-deps.yml
+++ b/workflows/update-deps.yml
@@ -2,7 +2,13 @@ name: Update NPM dependencies
 
 on:
   schedule:
-  - cron: "0 5 * * 1"
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+    inputs:
+      config:
+        description: 'Config'
+        required: false
+        default: ''
 
 jobs:
   update:
@@ -15,10 +21,14 @@ jobs:
     steps:
       - name: Read config
         run: |
-          echo "SETTINGS={}" >> $GITHUB_ENV
-          if [[ -f "./.github/workflows-config.json" ]]; then
-            echo "SETTINGS=$( jq .updateDeps './.github/workflows-config.json' )" >> $GITHUB_ENV
+          CONFIG='{}'
+          if [[ ! -z '${{ github.event.inputs.config }}' ]]; then
+            CONFIG='${{ github.event.inputs.config }}'
+          elif [[ -f "./.github/workflows-config.json" ]]; then
+            CONFIG=$( jq .updateDeps './.github/workflows-config.json' )
           fi
+          echo "CONFIG=$CONFIG" >> $GITHUB_ENV
+          echo "Workflow config: $CONFIG"
 
       - name: Setup node
         # https://github.com/marketplace/actions/setup-node-js-environment
@@ -40,13 +50,12 @@ jobs:
             echo "Expected 'GH_BOT_EMAIL' secret variable to be set."
             exit 1
           fi
-          BRANCH_MAIN=$(echo ${{ env.SETTINGS }} | jq ".branchMain")
-          if [[ -z "$BRANCH_MAIN" ]]; then
+          BRANCH_MAIN=$(echo '${{ env.CONFIG }}' | jq -r ".branchMain")
+          if [[ -z "$BRANCH_MAIN" || "$BRANCH_MAIN" == "null" ]]; then
             # Since 'Fetch changes' step fetches default branch, we just get branch name (which will be default one).
-            echo "BRANCH_MAIN=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
-          else
-            echo "$BRANCH_MAIN" >> $GITHUB_ENV
+            BRANCH_MAIN=$(git rev-parse --abbrev-ref HEAD)
           fi
+          echo "BRANCH_MAIN=$BRANCH_MAIN" >> $GITHUB_ENV
 
       - name: Check if update branch already exists
         run: |

--- a/workflows/update-deps.yml
+++ b/workflows/update-deps.yml
@@ -19,6 +19,12 @@ jobs:
         deps: [production, dev-only]
 
     steps:
+      - name: Setup node
+        # https://github.com/marketplace/actions/setup-node-js-environment
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+
       - name: Checkout default branch
         # https://github.com/marketplace/actions/checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
As mentioned in https://github.com/ckeditor/ckeditor4-workflows-common/issues/6#issuecomment-745287750:

> > We may try to fiddle with bot/token permissions to see if it's possible to workaround.
> 
> At the moment, bot has `Write` access in `ckeditor4` repostiory. To be able to push despite branch protection rules, it would need to have `Admin` access which I think is rather a bad idea... It should have as little permissions as possible. So the other solution is to go with:
> 
> > If not, other solution may be to adjust the workflow (via config flag, see [#4](https://github.com/ckeditor/ckeditor4-workflows-common/issues/4)) so it creates a PR instead of pushing directly to main branch.
> 
> Let's try the later approach and see how it works.

So I went with configuration option which allows to alter the workflow to create PR instead of pushing directly to main branch. Since it doesn't make sense to keep configuration in GH secrets I have introduced optional JSON config file (#4).

The above needs proper explanation so I took this occasion to improve README file and describe all common workflows we have now.

The default flow and the one wit PR were tested in separate test repos:

* https://github.com/ckeditor/workflows-test-1
* https://github.com/ckeditor/workflows-test-2

Closes #6. Closes #4.