### PR TITLE
Fix Create PR condition in setup-workflows

### DIFF
--- a/workflows/setup-workflows.yml
+++ b/workflows/setup-workflows.yml
@@ -110,7 +110,7 @@ jobs:
           branch: ${{ env.BRANCH_SOURCE }}
 
       - name: Create PR
-        if: env.AS_PR == 1
+        if: env.HAS_CHANGES == 1 && env.AS_PR == 1
         # https://github.com/marketplace/actions/github-pull-request-action
         uses: repo-sync/pull-request@v2
         with:


### PR DESCRIPTION
Since as a last step only 'AS_PR' was checked ignoring 'HAS_CHANGES' flag, the workflow tried pushing the PR even though there were no changes (and no PR branch) - see https://github.com/ckeditor/ckeditor4/runs/2018655044?check_suite_focus=true.

I skipped creating issues for this change intentionally.