### PR TITLE
Exclude PR & Issues assignee to team members from stalebot workflow

### DIFF
--- a/workflows/stalebot.yml
+++ b/workflows/stalebot.yml
@@ -19,7 +19,7 @@ jobs:
         stale-pr-label: 'stale'
         exempt-issue-labels: 'status:confirmed,status:blocked'
         exempt-pr-labels: 'status:blocked'
-        exempt-assignees: 'Comandeer,sculpt0r,jacekbogdanski,Dumluregn,MMMalik'
+        exempt-assignees: 'Comandeer,sculpt0r,jacekbogdanski,Dumluregn,MMMalik,KarolDawidziuk'
         close-issue-label: 'resolution:expired'
         close-pr-label: 'pr:frozen ❄'
         remove-stale-when-updated: true

--- a/workflows/stalebot.yml
+++ b/workflows/stalebot.yml
@@ -19,6 +19,7 @@ jobs:
         stale-pr-label: 'stale'
         exempt-issue-labels: 'status:confirmed,status:blocked'
         exempt-pr-labels: 'status:blocked'
+        exempt-assignees: 'Comandeer,sculpt0r,jacekbogdanski,Dumluregn,MMMalik'
         close-issue-label: 'resolution:expired'
         close-pr-label: 'pr:frozen ❄'
         remove-stale-when-updated: true


### PR DESCRIPTION
I decide to use: https://github.com/marketplace/actions/close-stale-issues#exempt-assignees option.

It requires keeping up to date the members in this place additionally, but it looks like the fastest and quite good solution. Also, the team members don't change that fast - I hope ;)

Also, it requires having at least someone assigned to the PR if we don't want it to be stale.
