### PR TITLE
Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/ckeditor/ckeditor4-workflows-common#readme",
   "dependencies": {
-    "@octokit/request": "^5.4.14",
-    "dotenv": "^8.2.0",
-    "chalk": "^4.1.0"
+    "@octokit/request": "^5.6.3",
+    "chalk": "^4.1.2",
+    "dotenv": "^10.0.0"
   }
 }


### PR DESCRIPTION
I decided not to remove the `package-lock` right now - since it might affect the CI - and we don't want that right before the release.